### PR TITLE
Preventing infinite error loop in test

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -30,11 +30,15 @@
   var updater = require('./updater.js');
   var upd = new updater(pkg);
   var newVersionCheckIntervalId = null;
+  var tryingForNewVersion = false;
 
   if(!copyPath){
     document.getElementById('version').innerHTML = 'current version ' + pkg.version;
     newVersionCheckIntervalId = setInterval(function(){
-      if(!d) upd.checkNewVersion(newVersionAvailable);
+      if(!d && !tryingForNewVersion) {
+          tryingForNewVersion = true; //lock
+          upd.checkNewVersion(newVersionAvailable);
+      }
     }, 500);
   } else {
     console.log("I will copy from", path.resolve(process.cwd(),'../../..'));
@@ -53,6 +57,7 @@
   }
 
   function newVersionAvailable(err, manifest){
+    tryingForNewVersion = false; //unlock
     if(err || d){
       console.log(err);
       clearInterval(newVersionCheckIntervalId);


### PR DESCRIPTION
This helps a little but for some weird reason there are still four identical errors thrown. 

The error is thrown because the request for `http://localhost:63061/package.json` fails. Is it expected to fail when requested from 0.0.2? Or should 0.0.2 get the manifest and then realise the app is up to date?
