### PR TITLE
Added links to repo from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,14 @@
   ],
   "version": "0.0.2",
   "main": "./app/updater.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/edjafarov/node-webkit-updater.git"
+  },
+  "bugs": {
+    "url": "https://github.com/edjafarov/node-webkit-updater/issues"
+  },
+  "homepage": "https://github.com/edjafarov/node-webkit-updater",
   "scripts": {
     "test": "node node_modules/grunt-cli/bin/grunt clean mochaTest"
   },


### PR DESCRIPTION
Without this, you can't get to the GitHub repo from https://www.npmjs.org/package/node-webkit-updater without doing a search.
