### PR TITLE
Example never updates upd.manifest before downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ var upd = new updater(pkg);
 upd.checkNewVersion(function(error, manifest) {
 	if (!error) {
 		// Insert your user download choice/version comparison code here
+		upd.manifest = manifest;
 		upgradeNow();
 	}
 });


### PR DESCRIPTION
Without this, it'll always try to download the existing version?
