### PR TITLE
Add -q option to unzip to avoid stdout maxbuffer exceeded

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -182,7 +182,7 @@
           extension = path.extname(filename);
 
       if(extension === ".zip"){
-        exec('unzip -xo ' + filename + ' >/dev/null',{cwd: os.tmpdir()}, function(err){
+        exec('unzip -xoq ' + filename + ' >/dev/null',{cwd: os.tmpdir()}, function(err){
           if(err){
             console.log(err);
             return cb(err);


### PR DESCRIPTION
I added the 'quiet' option to the unzip command, it permits to avoid the error 'stdout maxbuffer exceeded' while unpacking large node-webkit apps.
