### PR TITLE
Unpack fixes

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -230,8 +230,8 @@
       var destinationDirectory = getZipDestinationDirectory(filename),
           unzip = function(){
             // unzip by C. Spieler (docs: https://www.mkssoftware.com/docs/man1/unzip.1.asp, issues: http://www.info-zip.org/)
-            exec(path.resolve(__dirname, 'tools/unzip.exe') + " -u -o " +
-                filename + " -d " + destinationDirectory, function(err){
+            exec( '"' + path.resolve(__dirname, 'tools/unzip.exe') + '" -u -o ' +
+                filename + ' -d ' + destinationDirectory + ' > NUL', function(err){
               if(err){
                 return cb(err);
               }
@@ -262,7 +262,7 @@
      */
     linux32: function(filename, cb, manifest){
       //filename fix
-      exec('tar -zxvf ' + filename,{cwd: os.tmpdir()}, function(err){
+      exec('tar -zxvf ' + filename + ' >/dev/null',{cwd: os.tmpdir()}, function(err){
         console.log(arguments);
         if(err){
           console.log(err);


### PR DESCRIPTION
1.Wrap path to unzip tool in quote marks (if path has spaces I did get an error)
2.Redirect stdout to NUL for win and linux.
