### PR TITLE
an errored download should not cause a successful callback

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -72,7 +72,8 @@
         if(err){
             cb(err);
         }
-        if(response.statusCode < 200 || response.statusCode > 299){
+        if(response.statusCode < 200 || response.statusCode >= 300){
+            pkg.abort();
             return cb(new Error(response.statusCode));
         }
     });
@@ -94,7 +95,9 @@
 
     function appDownloaded(){
       process.nextTick(function(){
-        cb(null, destinationPath)
+        if(pkg.response.statusCode >= 200 && pkg.response.statusCode < 300){
+          cb(null, destinationPath);
+        }
       });
     }
     return pkg;


### PR DESCRIPTION
I have also made it abort the download - Im not sure if you wanted it to download the errored requests content. 

The other option is to let the download fully complete, callback at the end with the error & file link. 

The current callback of error AND callback of response (with no error indication) seems broken tho
