### PR TITLE
Fix exception when download file doesn't exist

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -72,7 +72,7 @@
         if(err){
             cb(err);
         }
-        if(response.statusCode < 200 || response.statusCode >= 300){
+        if(response && (response.statusCode < 200 || response.statusCode >= 300)){
             pkg.abort();
             return cb(new Error(response.statusCode));
         }


### PR DESCRIPTION
If the package.json from the manifestUrl exists, and the app needs an
update, but the file from the update/download link doesn't exist node
throws an exception and dies. This allows the script to continue.