### PR TITLE
bypass dmg interaction

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -190,7 +190,7 @@
       }
 
       if(extension === ".zip"){
-        exec('unzip -xo ' + filename + ' >/dev/null',{ cwd: destination }, function(err){
+        exec('unzip -xo "' + filename + '" >/dev/null',{ cwd: destination }, function(err){
           if(err){
             console.log(err);
             return cb(err);
@@ -205,8 +205,8 @@
         exec('hdiutil unmount /Volumes/'+path.basename(filename, '.dmg'), function(err){
           // create a CDR from the DMG to bypass any steps which require user interaction
           var cdrPath = filename.replace(/.dmg$/, '.cdr');
-          exec('hdiutil convert ' + filename + ' -format UDTO -o ' + cdrPath, function(err){
-            exec('hdiutil attach ' + cdrPath + ' -nobrowse', function(err){
+          exec('hdiutil convert "' + filename + '" -format UDTO -o "' + cdrPath + '"', function(err){
+            exec('hdiutil attach "' + cdrPath + '" -nobrowse', function(err){
               if(err) {
                 if(err.code == 1){
                   pUnpack.mac.apply(this, args);
@@ -274,7 +274,7 @@
      */
     linux32: function(filename, cb, manifest){
       //filename fix
-      exec('tar -zxvf ' + filename + ' >/dev/null',{cwd: os.tmpdir()}, function(err){
+      exec('tar -zxvf "' + filename + '" >/dev/null',{cwd: os.tmpdir()}, function(err){
         console.log(arguments);
         if(err){
           console.log(err);

--- a/app/updater.js
+++ b/app/updater.js
@@ -203,14 +203,18 @@
       else if(extension === ".dmg"){
         // just in case if something was wrong during previous mount
         exec('hdiutil unmount /Volumes/'+path.basename(filename, '.dmg'), function(err){
-          exec('hdiutil attach ' + filename + ' -nobrowse', function(err){
-            if(err) {
-              if(err.code == 1){
-                pUnpack.mac.apply(this, args);
+          // create a CDR from the DMG to bypass any steps which require user interaction
+          var cdrPath = filename.replace(/.dmg$/, '.cdr');
+          exec('hdiutil convert ' + filename + ' -format UDTO -o ' + cdrPath, function(err){
+            exec('hdiutil attach ' + cdrPath + ' -nobrowse', function(err){
+              if(err) {
+                if(err.code == 1){
+                  pUnpack.mac.apply(this, args);
+                }
+                return cb(err);
               }
-              return cb(err);
-            }
-            findMountPoint(path.basename(filename, '.dmg'), cb);
+              findMountPoint(path.basename(filename, '.dmg'), cb);
+            });
           });
         });
 


### PR DESCRIPTION
When trying to update from a dmg that has a built in EULA, the necessary user interaction of the EULA causes node-webkit-updater to hang/fail as reported in issue #76.

**Changes:**
- Converted the dmg to a cdr before attaching the volume. This removes the need for any user interactions allowing the update to succeed.
- Added double quotes around file names in exec() calls so that file names with spaces don't break the update process.

I was not able to run tests as reported in issue #77.