### PR TITLE
fix basic example, which will fail on Windows

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -12,6 +12,7 @@
 var gui = require('nw.gui');
 var pkg = require('../package.json'); // Insert your app's manifest here
 var updater = require('node-webkit-updater');
+var path = require('path')
 var upd = new updater(pkg);
 var copyPath, execPath;
 
@@ -44,9 +45,9 @@ else { // if no arguments were passed to the app
                     // ------------- Step 3 -------------
                     upd.unpack(filename, function(error, newAppPath) {
                         if (!error) {
-
+							var newAppDir = path.dirname(newAppPath); 
                             // ------------- Step 4 -------------
-                            upd.runInstaller(newAppPath, [upd.getAppPath(), upd.getAppExec()],{});
+                            upd.runInstaller(newAppPath, [upd.getAppPath(), upd.getAppExec()], {cwd: newAppDir} );
                             gui.App.quit();
                         }
                     }, manifest);


### PR DESCRIPTION
I encounter the same problem described in issue #90, and I figured out the reason:
In step 4 when installer is run, it's cwd is default to the cwd of the current process, which is very likely the directory of the current application. Finally when installer is running, it can't delete installation destination directory, because itself is using it.

The fix is as simple as setting the cwd of installer to it's own directory.
